### PR TITLE
feat: Add Drag and Drop support for Spaces and Groups

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,9 @@
         "@base-ui/react": "^1.0.0",
         "@bookmarks/shared-types": "github:wavilikhin/bookmarks-index-types",
         "@clerk/chrome-extension": "^2.8.14",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/inter": "^5.2.8",
         "@reatom/core": "^1000.1.0",
         "@reatom/react": "^1000.0.0",
@@ -165,6 +168,14 @@
     "@clerk/types": ["@clerk/types@4.101.9", "", { "dependencies": { "@clerk/shared": "^3.41.1" } }, "sha512-RO00JqqmkIoI1o0XCtvudjaLpqEoe8PRDHlLS1r/aNZazUQCO0TT6nZOx1F3X+QJDjqYVY7YmYl3mtO2QVEk1g=="],
 
     "@coinbase/wallet-sdk": ["@coinbase/wallet-sdk@4.3.0", "", { "dependencies": { "@noble/hashes": "^1.4.0", "clsx": "^1.2.1", "eventemitter3": "^5.0.1", "preact": "^10.24.2" } }, "sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.51.4", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-AoziS8lRQ3ew/lY5J4JSlzYSN9Fo0oiyMBY37L3Bwq4mOQJT5GSrdZYLFPt6pH1LApDI3ZJceNyx+rHRACZSeQ=="],
 

--- a/package.json
+++ b/package.json
@@ -36,9 +36,12 @@
     }
   },
   "dependencies": {
-    "@bookmarks/shared-types": "github:wavilikhin/bookmarks-index-types",
     "@base-ui/react": "^1.0.0",
+    "@bookmarks/shared-types": "github:wavilikhin/bookmarks-index-types",
     "@clerk/chrome-extension": "^2.8.14",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/inter": "^5.2.8",
     "@reatom/core": "^1000.1.0",
     "@reatom/react": "^1000.0.0",

--- a/src/screens/main-screen/main-screen.tsx
+++ b/src/screens/main-screen/main-screen.tsx
@@ -24,8 +24,8 @@ import {
   GROUP_ICONS,
   getRandomIcon
 } from '@/stores/ui/atoms'
-import { createSpace, updateSpace, deleteSpace, spacesAtom } from '@/domain/spaces'
-import { groupsAtom, createGroup, updateGroup, deleteGroup } from '@/domain/groups'
+import { createSpace, updateSpace, deleteSpace, spacesAtom, reorderSpaces } from '@/domain/spaces'
+import { groupsAtom, createGroup, updateGroup, deleteGroup, reorderGroups } from '@/domain/groups'
 import {
   bookmarksAtom,
   bookmarksLoadingAtom,
@@ -380,6 +380,23 @@ export const MainScreen = reatomComponent(() => {
   const bookmarksLoading = bookmarksLoadingAtom()
   const bookmarksError = bookmarksErrorAtom()
 
+  // Reorder handlers
+  const handleReorderSpaces = async (orderedIds: string[]) => {
+    try {
+      await reorderSpaces(orderedIds)
+    } catch (error) {
+      console.error('Failed to reorder spaces:', error)
+    }
+  }
+
+  const handleReorderGroups = async (spaceId: string, orderedIds: string[]) => {
+    try {
+      await reorderGroups(spaceId, orderedIds)
+    } catch (error) {
+      console.error('Failed to reorder groups:', error)
+    }
+  }
+
   // Render sidebar slot
   const sidebarSlot = (
     <SpacesSidebar
@@ -395,6 +412,7 @@ export const MainScreen = reatomComponent(() => {
       onToggleCollapse={toggleSidebar}
       onSpaceSave={handleSpaceSave}
       onSpaceCancel={handleSpaceCancel}
+      onReorderSpaces={handleReorderSpaces}
     />
   )
 
@@ -428,12 +446,14 @@ export const MainScreen = reatomComponent(() => {
                 draftGroup={draftGroup}
                 activeGroupId={selectedGroupId}
                 editingGroupId={editingGroupId}
+                spaceId={activeSpaceId}
                 onSelectGroup={setSelectedGroup}
                 onAddGroup={handleAddGroup}
                 onEditGroup={(group) => startEditingGroup(group)}
                 onDeleteGroup={(group) => openDeleteDialog('group', group)}
                 onGroupNameSave={handleGroupNameSave}
                 onGroupNameCancel={handleGroupCancel}
+                onReorderGroups={handleReorderGroups}
                 className="mb-4"
               />
               {/* Bookmark grid */}


### PR DESCRIPTION
## Summary

Implements drag and drop reordering for Spaces (sidebar) and Groups (tabs).

## Changes

- Added `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` dependencies
- Implemented vertical DnD for SpacesSidebar with smooth animations
- Implemented horizontal DnD for GroupTabs
- Used `DragOverlay` for smooth dragging without layout issues when dragging outside bounds
- Updated reorder actions in domain models to properly reorder atom arrays
- Optimistic updates with automatic rollback on error

## UX Details

- Whole item is draggable (no separate drag handle icon)
- Visual feedback: original item dims, overlay clone follows cursor
- Snappy feel with disabled CSS transitions during drag
- Items smoothly animate to preview new positions
- Works with keyboard navigation (accessibility)

Fixes #10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces drag-and-drop reordering across the app with smooth UX and safe state handling.
> 
> - Integrates `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` for DnD
> - Implements vertical DnD in `SpacesSidebar` and horizontal DnD in `GroupTabs` using `DndContext`, `SortableContext`, `DragOverlay`, and pointer sensors
> - Wires `onReorderSpaces`/`onReorderGroups` from `MainScreen` to domain actions
> - Refactors `reorderSpaces`/`reorderGroups` to rebuild atom arrays, update `order`, and support optimistic updates with full rollback on error
> - Minor UI tweaks for drag states (grab cursors, opacity, transitions) and event handling to avoid unintended drags
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3404cbf2d0c978fad1143ab3e655e47e23883df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->